### PR TITLE
a poor-man's ProtoDUNE-SP event display -- hit time vs. channel

### DIFF
--- a/demo2.C
+++ b/demo2.C
@@ -10,12 +10,11 @@
 #include "TH2F.h"
 #include "TInterpreter.h"
 #include "TROOT.h"
-#include "TGraph.h"
 
 using namespace art;
 using namespace std;
 
-// make a poor-man's event display of recob::hits -- pektime vs. channel, for the ievcount'th event in the file
+// make a poor-man's event display of recob::hits -- peaktime vs. channel, for the ievcount'th event in the file
 
 void
 demo2(std::string const& filename, size_t ievcount)

--- a/demo2.C
+++ b/demo2.C
@@ -1,0 +1,48 @@
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "canvas/Utilities/InputTag.h"
+#include "gallery/Event.h"
+
+#include "TFile.h"
+#include "TH2F.h"
+#include "TInterpreter.h"
+#include "TROOT.h"
+#include "TGraph.h"
+
+using namespace art;
+using namespace std;
+
+// make a poor-man's event display of recob::hits -- pektime vs. channel, for the ievcount'th event in the file
+
+void
+demo2(std::string const& filename, size_t ievcount)
+{
+
+  size_t evcounter=0;
+
+  InputTag recobhit_tag{ "gaushit" };
+  // Create a vector of length 1, containing the given filename.
+  vector<string> filenames(1, filename);
+
+  TH2F *evh = new TH2F("evh","TH2F event display;Channel Number;Hit Time (ticks)",500,-0.5,15100,500,0,8000);
+
+  for (gallery::Event ev(filenames); !ev.atEnd(); ev.next()) {
+    if (evcounter == ievcount)
+      {
+	auto const& recobhits = *ev.getValidHandle<vector<recob::Hit>>(recobhit_tag);
+	if (!recobhits.empty())
+	  {
+	    for (size_t ihit=0;ihit<recobhits.size(); ++ihit)
+	      {
+		evh->Fill(recobhits[ihit].Channel(),recobhits[ihit].PeakTime());
+	      }
+	    evh->SetStats(0);
+	    evh->Draw("colz");
+	  }
+      }
+    ++evcounter;
+  }
+}

--- a/demo3.C
+++ b/demo3.C
@@ -1,0 +1,54 @@
+#include <functional>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "canvas/Utilities/InputTag.h"
+#include "gallery/Event.h"
+
+#include "TFile.h"
+#include "TInterpreter.h"
+#include "TROOT.h"
+#include "TGraph.h"
+
+using namespace art;
+using namespace std;
+
+// make a poor-man's event display of recob::hits -- peaktime vs. channel, for the ievcount'th event in the file
+
+void
+demo3(std::string const& filename, size_t ievcount)
+{
+
+  size_t evcounter=0;
+
+  InputTag recobhit_tag{ "gaushit" };
+  // Create a vector of length 1, containing the given filename.
+  vector<string> filenames(1, filename);
+
+  for (gallery::Event ev(filenames); !ev.atEnd(); ev.next()) {
+    if (evcounter == ievcount)
+      {
+	auto const& recobhits = *ev.getValidHandle<vector<recob::Hit>>(recobhit_tag);
+	if (!recobhits.empty())
+	  {
+	    vector<double> xvals;
+	    vector<double> yvals;
+
+	    for (size_t ihit=0;ihit<recobhits.size(); ++ihit)
+	      {
+		xvals.push_back(recobhits[ihit].Channel());
+		yvals.push_back(recobhits[ihit].PeakTime());
+	      }
+	    TGraph *gr = new TGraph(xvals.size(),xvals.data(),yvals.data());
+	    gr->SetMarkerColor(1);
+	    gr->SetMarkerStyle(1);
+	    gr->SetTitle("TGraph Event Display");
+	    gr->GetXaxis()->SetTitle("Channel");
+	    gr->GetYaxis()->SetTitle("Tick");
+	    gr->Draw("AP");
+	  }
+      }
+    ++evcounter;
+  }
+}


### PR DESCRIPTION
demo2.C (I only wrote the version for interactive use.)  Picks one event out of the file based on the count and fills a TH2F with hit times vs. channel numbers.  You get induction-plane and collection-plane hits on all APA's all mashed together.